### PR TITLE
Ability to delete key

### DIFF
--- a/lib/i18n_yaml_editor/web.rb
+++ b/lib/i18n_yaml_editor/web.rb
@@ -41,7 +41,11 @@ module I18nYamlEditor
       on post, "update" do
         if translations = req["translations"]
           translations.each {|name, text|
-            app.store.translations[name].text = text
+            if text == '__delete__'
+              app.store.translations.delete(name)
+            else
+              app.store.translations[name].text = text
+            end
           }
           app.save_translations
         end

--- a/views/translations.html.erb
+++ b/views/translations.html.erb
@@ -30,6 +30,7 @@
             <% end %>
           </table>
         </td>
+        <td><a class='delete' href="#">delete</a></td>
       </tr>
     <% end %>
   </table>
@@ -50,5 +51,12 @@
   $('.header .pull-right').append("<button id='save-on-top'>Save</button>")
   $('#save-on-top').click(function() {
     $('#updateform').submit();
+  });
+  $('a.delete').click(function(e){
+    e.preventDefault();
+    var keyrow = $(e.target).parents('.translation');
+    var values = $(keyrow).find('textarea, input[type=text]');
+    values.val('__delete__');
+    keyrow.hide();
   });
 </script>


### PR DESCRIPTION
This adds the ability to delete a key from IYE:

![screenshot 2015-04-18 17 57 44](https://cloud.githubusercontent.com/assets/3245/7216371/d0371194-e5f4-11e4-825a-99fb9cdffb51.png)

The key is deleted only when you press "Save" as part of the normal /update action.

Video of the feature: https://www.dropbox.com/s/fg3c27yprkien48/iye_delete_key.mov?dl=0
